### PR TITLE
Update EUValueSetRepository.kt

### DIFF
--- a/covpass-sdk/src/main/java/de/rki/covpass/sdk/storage/EUValueSetRepository.kt
+++ b/covpass-sdk/src/main/java/de/rki/covpass/sdk/storage/EUValueSetRepository.kt
@@ -23,7 +23,7 @@ internal object EUValueSetRepository {
                 version = ""
             ),
             "EU/1/20/1507" to EUValueSetValue(
-                display = "COVID-19 Vaccine Moderna",
+                display = "Spikevax (previously COVID-19 Vaccine Moderna)",
                 lang = "en",
                 active = true,
                 system = "https://ec.europa.eu/health/documents/community-register/html/",


### PR DESCRIPTION
Change "COVID-19 Vaccine Moderna" to "Spikevax (previously COVID-19 Vaccine Moderna)"
As per Value Sets for EU Digital COVID Certificates https://ec.europa.eu/health/sites/default/files/ehealth/docs/digital-green-value-sets_en.pdf
Fixes Issue #124


<!---Description/motivation above this comment please -->

## Ticket id

<!---Mentioning the ticket id automatically links to Jira. -->

EBH-

## Checklist

- [X] The CHANGELOG is up to date with public API changes.
- [X] The documentation is up to date and in a good shape.
- [X] The unit tests for new code I've added are in a good shape.
- [X] These changes are compatible with R8/ProGuard.
